### PR TITLE
Improve accessibility across the site (WCAG 2.1 AA)

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -73,6 +73,8 @@ const Map = ({ locations }) => {
         zoom={zoomLevel}
         onLoad={onLoad}
         onZoomChanged={onZoomChanged}
+        options={{ mapTypeControlOptions: { position: undefined } }}
+        aria-label="Map showing reviewed parmi locations"
       >
         {locations.map((location, index) => (
           <Marker

--- a/components/blocks/best-parmi.tsx
+++ b/components/blocks/best-parmi.tsx
@@ -181,7 +181,7 @@ export const BestParmi = ({
 
               <div className="flex flex-col gap-4 text-sm text-white/80 sm:flex-row sm:items-center sm:gap-6">
                 <div className="flex items-center gap-4">
-                  <span className="flex h-14 w-14 items-center justify-center rounded-full bg-white text-3xl text-[#d85530]">
+                  <span className="flex h-14 w-14 items-center justify-center rounded-full bg-white text-3xl text-[#d85530]" aria-hidden="true">
                     ★
                   </span>
                   <div>

--- a/components/layout/breadcrumb.tsx
+++ b/components/layout/breadcrumb.tsx
@@ -64,7 +64,7 @@ const NextBreadcrumb = () => {
                 </li>
                 <li>
                   {isLast ? (
-                    <span className="rounded-full bg-transparent px-2 py-1">{cleanUpLink(link)}</span>
+                    <span className="rounded-full bg-transparent px-2 py-1" aria-current="page">{cleanUpLink(link)}</span>
                   ) : (
                     <Link
                       className={`rounded-full px-2 py-1 transition ${itemClasses}`}

--- a/components/layout/footer/footer.tsx
+++ b/components/layout/footer/footer.tsx
@@ -37,7 +37,7 @@ export const Footer = ({ data }) => {
   };
 
   return (
-    <footer className="bg-[#d85530] text-white">
+    <footer className="bg-[#d85530] text-white" role="contentinfo">
       <Container
         className="flex flex-col gap-8 py-10 md:flex-row md:items-center md:justify-between"
         size="large"

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -47,6 +47,7 @@ export const Header = ({ data }) => {
         className={`rounded-full px-4 py-2 ${baseClasses} ${
           mobile ? mobileClasses : desktopClasses
         }`}
+        {...(isActive ? { "aria-current": "page" as const } : {})}
       >
         {item.label}
       </Link>
@@ -56,8 +57,8 @@ export const Header = ({ data }) => {
   return (
     <header className="bg-[#d85530] text-white">
       <Container size="custom" className="max-w-6xl py-5">
-        <nav className="flex items-center justify-between gap-6">
-          <Link href="/" className="flex items-center gap-4">
+        <nav className="flex items-center justify-between gap-6" aria-label="Main navigation">
+          <Link href="/" className="flex items-center gap-4" aria-label="Parmi Picks home">
             <Image 
                   src="/parmi-picks-logo.svg" 
                   alt="Parmi Picks Logo" 
@@ -87,7 +88,7 @@ export const Header = ({ data }) => {
         </nav>
 
         {expanded && (
-          <div className="mt-4 rounded-3xl border border-white/30 bg-white/10 px-6 py-5 md:hidden">
+          <div className="mt-4 rounded-3xl border border-white/30 bg-white/10 px-6 py-5 md:hidden" role="navigation" aria-label="Mobile navigation">
             <div className="flex flex-col gap-3">
               {navItems.map((item, index) => renderNavItem(item, index, true))}
             </div>

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -32,11 +32,17 @@ export const Layout = ({ data = layoutData, children }) => {
         <meta name="robots" content="index, follow" />{" "}
       </Head>
       <div className="flex min-h-screen flex-col">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-full focus:bg-[#d85530] focus:px-6 focus:py-3 focus:text-sm focus:font-semibold focus:text-white focus:shadow-lg"
+        >
+          Skip to main content
+        </a>
         <Header data={data?.header} />
-        <div className="flex flex-1 flex-col">
+        <main id="main-content" className="flex flex-1 flex-col">
           <NextBreadcrumb />
           {children}
-        </div>
+        </main>
         <Footer data={data?.footer} />
       </div>
     </>

--- a/components/posts/reviews.tsx
+++ b/components/posts/reviews.tsx
@@ -36,7 +36,7 @@ export const Reviews = ({
             <article className="mb-8 rounded-3xl border-2 border-[#6b63ff] bg-[#d85530] px-8 py-9 text-white shadow-lg transition hover:-translate-y-1 hover:shadow-xl">
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex items-start gap-4">
-                  <span className="inline-flex h-14 w-14 items-center justify-center rounded-full border-4 border-white bg-[#fff3ee] text-lg font-bold text-[#d85530] shadow-inner">
+                  <span className="inline-flex h-14 w-14 items-center justify-center rounded-full border-4 border-white bg-[#fff3ee] text-lg font-bold text-[#d85530] shadow-inner" aria-label={`Score: ${post.score} out of 10`} role="img">
                     {post.score}
                   </span>
                   <div>
@@ -50,7 +50,7 @@ export const Reviews = ({
                 </div>
                 <span className="hidden items-center gap-2 text-sm font-medium text-white/70 sm:inline-flex">
                   Read review
-                  <BsArrowRight className="h-4 w-4 transition group-hover:translate-x-1" />
+                  <BsArrowRight className="h-4 w-4 transition group-hover:translate-x-1" aria-hidden="true" />
                 </span>
               </div>
             </article>

--- a/components/util/actions.tsx
+++ b/components/util/actions.tsx
@@ -20,6 +20,7 @@ export const Actions = ({ parentField = "", className = "", actions }) => {
                 {action.icon && (
                   <BiRightArrowAlt
                     className="h-5 w-5 transition-transform group-hover:translate-x-1"
+                    aria-hidden="true"
                   />
                 )}
               </Link>
@@ -33,7 +34,7 @@ export const Actions = ({ parentField = "", className = "", actions }) => {
               <span className="group inline-flex items-center gap-2">
                 {action.label}
                 {action.icon && (
-                  <BiRightArrowAlt className="h-5 w-5 transition-transform group-hover:translate-x-1" />
+                  <BiRightArrowAlt className="h-5 w-5 transition-transform group-hover:translate-x-1" aria-hidden="true" />
                 )}
               </span>
             );

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from "next/document";
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/pages/blogs/index.tsx
+++ b/pages/blogs/index.tsx
@@ -72,7 +72,7 @@ export default function BlogsPage(
                             <div className="flex items-center mr-4">
                               <Image
                                 src={post.node.author.avatar}
-                                alt={post.node.author.name}
+                                alt={`Avatar of ${post.node.author.name}`}
                                 width={24}
                                 height={24}
                                 className="rounded-full mr-2"
@@ -80,7 +80,7 @@ export default function BlogsPage(
                               <span>{post.node.author.name}</span>
                             </div>
                           )}
-                          <time>{formattedDate}</time>
+                          <time dateTime={post.node.date}>{formattedDate}</time>
                         </div>
                       </div>
                     </article>

--- a/pages/reviews/[filename].tsx
+++ b/pages/reviews/[filename].tsx
@@ -105,7 +105,7 @@ export default function ReviewPage(
                   <Image
                     className="h-14 w-14 object-cover rounded-full shadow-sm"
                     src={data.review.author.avatar}
-                    alt={data.review.author.name}
+                    alt={`Avatar of ${data.review.author.name}`}
                     height={56}
                     width={56}
                   />
@@ -118,12 +118,13 @@ export default function ReviewPage(
                 </span>
               </>
             )}
-            <p
+            <time
               data-tinafield="date"
+              dateTime={data.review.date}
               className="text-base text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-150"
             >
               {formattedDate}
-            </p>
+            </time>
           </div>
         </Container>
         <Container className={`flex-1 pt-4`} width="small" size="large">
@@ -131,9 +132,9 @@ export default function ReviewPage(
             <TinaMarkdown content={data.review._body} />
           </div>
           <div className="mt-12 rounded-3xl border border-amber-200/60 bg-gradient-to-br from-amber-50/80 via-white to-emerald-50/80 p-8 shadow-lg shadow-amber-100/40">
-            <h3 className="text-2xl font-semibold text-slate-900">
+            <h2 className="text-2xl font-semibold text-slate-900">
               Plan your visit
-            </h3>
+            </h2>
             <p className="mt-2 text-sm text-slate-500">
               Find {restaurant.name} on the map and plan your next parmi pilgrimage.
             </p>

--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,12 @@
   }
 }
 
+@layer base {
+  *:focus-visible {
+    @apply outline-2 outline-offset-2 outline-[#d85530];
+  }
+}
+
 @layer utilities {
   .backdrop-card {
     @apply border border-white/60 bg-white/70 shadow-xl shadow-slate-200/60 backdrop-blur;


### PR DESCRIPTION
## Summary

Comprehensive accessibility audit and fixes targeting WCAG 2.1 AA compliance across the entire Parmi Picks site.

### Changes

**Document-level**
- Add `_document.tsx` with `lang="en"` attribute on `<html>` element
- Add a skip navigation link ("Skip to main content") that appears on keyboard focus
- Replace content wrapper `<div>` with semantic `<main>` landmark element
- Add global `focus-visible` outline styles in `styles.css` for consistent keyboard focus indicators

**Navigation (`header.tsx`)**
- Add `aria-label="Main navigation"` to the primary `<nav>` element
- Add `aria-label="Parmi Picks home"` to the logo home link
- Add `aria-current="page"` to the active nav item
- Add `role="navigation"` and `aria-label="Mobile navigation"` to the mobile menu

**Breadcrumb (`breadcrumb.tsx`)**
- Add `aria-current="page"` to the last breadcrumb item

**Footer (`footer.tsx`)**
- Add explicit `role="contentinfo"` to the `<footer>` element

**Review detail page (`reviews/[filename].tsx`)**
- Fix heading hierarchy: change "Plan your visit" from `<h3>` to `<h2>` (was skipping h2)
- Wrap date in semantic `<time>` element with `dateTime` attribute (was `<p>`)
- Improve author avatar alt text to "Avatar of [name]"

**Blog listing page (`blogs/index.tsx`)**
- Add `dateTime` attribute to `<time>` elements
- Improve author avatar alt text to "Avatar of [name]"

**Review cards (`reviews.tsx`)**
- Add `role="img"` and `aria-label="Score: X out of 10"` to score badges
- Add `aria-hidden="true"` to decorative arrow icon

**Actions component (`actions.tsx`)**
- Add `aria-hidden="true"` to all decorative `BiRightArrowAlt` icons

**Best Parmi block (`best-parmi.tsx`)**
- Add `aria-hidden="true"` to decorative star character

**Map component (`Map.tsx`)**
- Add `aria-label` to the Google Map container

## Test plan

- [ ] Tab through the site with keyboard only -- verify skip link appears and all interactive elements receive visible focus
- [ ] Run a screen reader (VoiceOver) through the home, reviews list, review detail, blogs, and map pages
- [ ] Verify heading hierarchy with a browser extension (e.g. HeadingsMap)
- [ ] Confirm `lang="en"` is present on the `<html>` element
- [ ] Check that score badges are announced as "Score: X out of 10" by screen readers
- [ ] Verify breadcrumb last item announces "current page"
- [ ] Confirm decorative icons are not announced by screen readers

🤖 Generated with [Claude Code](https://claude.com/claude-code)